### PR TITLE
feat: enrich and generalize tool documentation

### DIFF
--- a/tool/autographql/JWT-token.txt
+++ b/tool/autographql/JWT-token.txt
@@ -1,1 +1,0 @@
-dummytoken

--- a/tool/autographql/README.md
+++ b/tool/autographql/README.md
@@ -4,26 +4,32 @@
 
 ---
 
+# Configure and extend your project to log the queries
+
+- use `./middleware/` as a sample written in TS for adding middleware and extending your project to track the queries being made and generate the `queries` directory, which is the expected input of the tool
+
 # Experiments with [Saleor](https://github.com/mirumee/saleor)
 
-- Set up saleor logging configurations, [like so](https://anonymous.4open.science/r/autographql-package/experiments/saleor-platform/README.md)
+- Set up saleor logging configurations
 - Create a [JWT token](https://docs.saleor.io/docs/2.9.0/api/authenticate/#creating-a-jwt-token) for Saleor
 - Generate and execute workloads! ✨
 
 ## Fetch queries
+eventually, you need to take the resulted `queries` directory out and place it beside `./runQueries.py`. In the `Saleor` scenario, you need to follow these steps:
 - `docker exec -it <container-id-for-saleor-platform_api_1> /bin/bash`
 - `python3 manage.py fetch_all_query_entries`
 - `docker cp <container-id-for-saleor-platform_api_1>:/app/queries /path/in/host/queries/`
 
 ## Generate tests with AutoGraphQL
-- Create directory `./testCases/`
-- Make sure the queries are saved in `./queries/`
-- Create a `./JWT-token.txt` with your Saleor JWT token
+- Make sure you did place the `./queries/` directory. Otherwise, you will get error
+- `AutoGraphQL` and `./runQueries.py` expect a `./testCases/` If you want your tests to be generated. If you only want some reports on coverage, skip to the next step
+- Open `./config.py`. Set your GraphQL endpoint as `graphql_url`. Also, if your project GraphQL api requires authentication for making queries, provide one as `authorization_token`
 - `pip3 install -r requirements.txt`
 - `python3 runQueries.py True`
 
 ## Run generated tests
-- Install and set up [composer](https://getcomposer.org/)
+The tests are generated in `./testCases/` with `PHPUnit`. So, you need to take the remaining steps having `PHP`:
+- Install and set up [composer](https://getcomposer.org/). you can use this [Link](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-composer-on-ubuntu-20-04) for ubuntu
 - In the directory with the tests, add `composer.json` with following code:
 ```
 {

--- a/tool/autographql/config.py
+++ b/tool/autographql/config.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python
 
-graphql_url = 'http://localhost:8000/graphql/'
+graphql_url = "" # example: "http://localhost:8000/graphql/"
 
 # JWT ***
-with open('./JWT-token.txt', 'r') as file:
-    token = file.read().replace('\n', '')
-authorization_token = "JWT " + token
+authorization_token = "" # example: "Bearer $TOKEN"
 
 schema_query = { "query": """query {
 __schema {

--- a/tool/autographql/middleware/logQueriesMiddleware.ts
+++ b/tool/autographql/middleware/logQueriesMiddleware.ts
@@ -1,0 +1,88 @@
+/* eslint-disable camelcase */
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+
+import dayjs from 'dayjs';
+import uuid from 'uuid';
+
+import { AppRequestHandler } from '$api/apiServices/application/AppRequestHandler';
+
+// a folder beside this middleware's definition
+const queriesDirectory = path.resolve(__dirname, './queries');
+
+interface QueryDetail {
+  query: string;
+  variables: any;
+  operation_name: string;
+  created_at: string;
+  updated_at: string;
+  times_called: number;
+}
+
+// it could be a redis client but it may not be supported by the project
+const queries: Record<string, QueryDetail> = {};
+
+// it restores the currently logged queries from previous sessions and server run
+if (fs.existsSync(queriesDirectory)) {
+  const files = fs.readdirSync(queriesDirectory);
+  for (const file of files) {
+    const fileJSON = fs.readFileSync(`${queriesDirectory}/${file}`, 'utf-8');
+    const fileObject = JSON.parse(fileJSON) as QueryDetail;
+    const queryKey = crypto
+      .createHash('sha256')
+      .update(fileObject.query + JSON.stringify(fileObject.variables))
+      .digest('hex');
+    queries[queryKey] = fileObject;
+  }
+}
+
+// it saves all of the queries with AutoGraphQL structure (uuid.json) regularly
+setInterval(() => {
+  if (fs.existsSync(queriesDirectory)) {
+    fs.rmSync(queriesDirectory, { recursive: true, force: true });
+  }
+  fs.mkdirSync(queriesDirectory);
+
+  for (const queryDetail of Object.values(queries)) {
+    fs.writeFileSync(
+      `${queriesDirectory}/${uuid.v4()}.json`,
+      JSON.stringify(queryDetail),
+    );
+  }
+}, 10000);
+
+// for each graphql request, it hashes the query+variables.
+// if this hash didn't exist in the queries dictionary, it creates one for it in the dictionary
+// and if it did, adds one to times called
+export const getLogQueriesMiddleware = (): AppRequestHandler => {
+  const logQueriesMiddleware: AppRequestHandler = (req, _, next) => {
+    const { query, operationName, variables } = req.body;
+    // we don't support mutation queries at the moment
+    if (query && !query.includes('mutation')) {
+      const queryKey = crypto
+        .createHash('sha256')
+        .update(query + JSON.stringify(variables))
+        .digest('hex');
+
+      const now = dayjs().format('YYYY-MM-DD HH:mm:ss');
+      if (queries[queryKey]) {
+        queries[queryKey].times_called = queries[queryKey].times_called + 1;
+        queries[queryKey].updated_at = now;
+      } else {
+        queries[queryKey] = {
+          query,
+          variables,
+          operation_name: operationName,
+          created_at: now,
+          updated_at: now,
+          times_called: 1,
+        };
+      }
+    }
+
+    next();
+  };
+
+  return logQueriesMiddleware;
+};

--- a/tool/autographql/runQueries.py
+++ b/tool/autographql/runQueries.py
@@ -33,7 +33,7 @@ def main():
     encoder = json.JSONEncoder()
 
     types = requests.post(cfg.graphql_url, data=encoder.encode(cfg.schema_query),
-                         headers={'content-type': 'application/json'})
+                         headers={'content-type': 'application/json', 'Authorization': cfg.authorization_token})
 
     schema = json.loads(types.content)['data']['__schema']
 


### PR DESCRIPTION
- There were some dark points in the tool's documentation that could make its users lost to start with it
- the steps are explained uniquely for `Saleor` project and it takes time for user to first experience the flow on this project and then use it for their own project so a little bit of generalization needed
- There was an unnecessary complexity in authentication parameter definition
- `graphql_url` has not been covered in any place of the documentations
- A TS middleware extension is added beside the tool itself as a sample for users to extend their projects and ready to generate expected AutoGraphQL inputs
- A paramater seemed to be missed for making `Introspection` query in case the project required Auth for it too